### PR TITLE
Add salt to creating hashes

### DIFF
--- a/apps/strapi/src/api/unsubscribe/controllers/unsubscribe.ts
+++ b/apps/strapi/src/api/unsubscribe/controllers/unsubscribe.ts
@@ -18,7 +18,7 @@ export default {
       await unsubscribeService.unsubscribeFromPosts(token)
 
       ctx.response.status = 200
-      ctx.send({ success:true })
+      ctx.send({ success: true })
     } catch (err) {
       ctx.body = err;
     }

--- a/apps/strapi/src/extensions/users-permissions/strapi-server.ts
+++ b/apps/strapi/src/extensions/users-permissions/strapi-server.ts
@@ -29,8 +29,8 @@ module.exports = (plugin) => {
       models: ['plugin::users-permissions.user'],
       async afterCreate(event: AfterXXXEvent) {
         // Send email to user with reset password
-        const confirmRegistrationHash = crypto.createHash('sha256').digest('hex').toString();
-        const unsubscribeHash = crypto.createHash('sha256').digest('hex').toString();
+        const confirmRegistrationHash = crypto.createHash('sha256').update(event.result.id.toString()).digest('hex').toString();
+        const unsubscribeHash = crypto.createHash('sha256').update(event.result.id.toString()).digest('hex').toString();
 
         const user = await strapi.entityService.update('plugin::users-permissions.user', event.result.id, {
           data: {


### PR DESCRIPTION
v rámci tohoto fixu jsem manuálně vygeneroval hashe pro `reset_password_token` a `unsubscribe_token` pro všech 155 uživatelů.